### PR TITLE
Return query parameter "v" in calls to vk.com

### DIFF
--- a/notification/vk_worker.go
+++ b/notification/vk_worker.go
@@ -201,6 +201,7 @@ func (w *VkWorker) sendRequest(method string, parameters map[string]string) erro
 	}
 	q.Add("access_token", w.token)
 	q.Add("client_secret", w.config.Secret)
+	q.Add("v", "5.37")
 	req.URL.RawQuery = q.Encode()
 
 	resp, err := w.client.Do(req)

--- a/notification/vk_worker.go
+++ b/notification/vk_worker.go
@@ -81,6 +81,7 @@ func (w *VkWorker) LenLevels() int {
 
 // Initialize load access token
 func (w *VkWorker) Initialize() error {
+	// https://vk.com/dev/access_token
 	req, err := http.NewRequest("GET", "https://oauth.vk.com/access_token", nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to create token request")
@@ -162,6 +163,7 @@ func (w *VkWorker) processLevelEvents() error {
 	parameters := map[string]string{
 		"levels": strings.Join(userLevels, ","),
 	}
+	// https://vk.com/dev/secure.setUserLevel deprecated
 	err := w.sendRequest("secure.setUserLevel", parameters)
 	if err != nil {
 		return err
@@ -180,6 +182,7 @@ func (w *VkWorker) processGeneralEvents() error {
 		"activity_id": strconv.Itoa(event.Type),
 		"value":       strconv.Itoa(event.Value),
 	}
+	// https://vk.com/dev/secure.sendNotification
 	err := w.sendRequest("secure.sendNotification", parameters)
 	if err != nil {
 		w.listEvents = append(w.listEvents[1:], w.listEvents[0]) // move to end of slice
@@ -201,6 +204,7 @@ func (w *VkWorker) sendRequest(method string, parameters map[string]string) erro
 	}
 	q.Add("access_token", w.token)
 	q.Add("client_secret", w.config.Secret)
+	// https://vk.com/dev/versions
 	q.Add("v", "5.37")
 	req.URL.RawQuery = q.Encode()
 
@@ -217,6 +221,7 @@ func (w *VkWorker) sendRequest(method string, parameters map[string]string) erro
 	if err != nil {
 		return errors.Wrap(err, "failed to decode vk response")
 	}
+	// https://vk.com/dev/errors
 	val, exist := rawResponse["error"]
 	if exist {
 		return fmt.Errorf("vk error response %v", val)

--- a/notification/vk_worker_test.go
+++ b/notification/vk_worker_test.go
@@ -13,7 +13,7 @@ func TestErrorOnInvalidResponse(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	httpmock.RegisterResponder(
-		"GET", "https://api.vk.com/method/mockMethod?access_token=&client_secret=secret&foo=bar",
+		"GET", "https://api.vk.com/method/mockMethod?access_token=&client_secret=secret&foo=bar&v=5.37",
 		httpmock.NewStringResponder(200, `{"error": "mock error"}`),
 	)
 	worker := NewVkWorker(VkConfig{
@@ -54,7 +54,7 @@ func TestSendLevelEvent(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	httpmock.RegisterResponder(
-		"GET", "https://api.vk.com/method/secure.setUserLevel?access_token=&client_secret=secret&levels=123%3A1%2C1234%3A4",
+		"GET", "https://api.vk.com/method/secure.setUserLevel?access_token=&client_secret=secret&levels=123%3A1%2C1234%3A4&v=5.37",
 		httpmock.NewStringResponder(200, `{}`),
 	)
 	worker := NewVkWorker(VkConfig{
@@ -90,7 +90,7 @@ func BenchmarkSendLevelEvent(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		httpmock.Activate()
 		httpmock.RegisterResponder(
-			"GET", "https://api.vk.com/method/secure.setUserLevel?access_token=&client_secret=secret&levels=123%3A1%2C1234%3A4",
+			"GET", "https://api.vk.com/method/secure.setUserLevel?access_token=&client_secret=secret&levels=123%3A1%2C1234%3A4&v=5.37",
 			httpmock.NewStringResponder(200, `{}`),
 		)
 		worker.batchLevels = append(worker.batchLevels, VkEvent{
@@ -116,7 +116,7 @@ func TestSendGeneralEvent(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	httpmock.RegisterResponder(
-		"GET", "https://api.vk.com/method/secure.sendNotification?access_token=&activity_id=2&client_secret=secret&user_id=123&value=1",
+		"GET", "https://api.vk.com/method/secure.sendNotification?access_token=&activity_id=2&client_secret=secret&user_id=123&v=5.37&value=1",
 		httpmock.NewStringResponder(200, `{}`),
 	)
 	worker := NewVkWorker(VkConfig{


### PR DESCRIPTION
Was removed in https://github.com/server-may-cry/bubble-go/commit/c1b7bd171e50afc35131f005cda4b87f4cc94b45#diff-ebbfe65c1a6cfd1cceaf6155ebb1956dL49